### PR TITLE
Change settings icon from translate to settings

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -73,7 +73,7 @@
     <div class="mdc-touch-target-wrapper">
       <button id="button" class="mdc-icon-button mdc-icon-button--touch material-icons">
         <div class="mdc-icon-button__ripple"></div>
-        translate
+        settings
         <div class="mdc-icon-button__touch"></div>
       </button>
     </div>


### PR DESCRIPTION
Updates the settings button icon from  to  in index.html to clarify that it opens configuration preferences rather than performing language translation.