### PR TITLE
fix: make Hanzi Writer completion flash color match theme accent color

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -363,6 +363,7 @@ class App {
 
     this.writer.updateColor('strokeColor', colors.stroke);
     this.writer.updateColor('highlightColor', colors.highlight);
+    this.writer.updateColor('highlightCompleteColor', this.color);
     this.writer.updateColor('outlineColor', colors.outline);
     this.writer.updateColor('drawingColor', colors.primary);
   }


### PR DESCRIPTION
Updates Hanzi Writer's highlightCompleteColor option when the theme changes to match the user-selected accent color. Fixes the issue where the completion flash color remained the default blue.