### PR TITLE
feat: fallback to keyboard/handwriting input method for unsupported characters

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,7 +92,19 @@
           <h2 id="jyutping">&nbsp;</h2>
           <ul id="definitions" class="mdc-list"></ul>
         </div>
-        <div id="target" class="mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop mdc-layout-grid__cell--span-12-tablet mdc-layout-grid__cell--span-12-phone"></div>
+        <div id="target-wrapper" class="mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop mdc-layout-grid__cell--span-12-tablet mdc-layout-grid__cell--span-12-phone">
+          <div id="target"></div>
+          <div id="fallback-container" style="display: none;">
+            <div id="fallback-prompt">Character not supported. Type or write:</div>
+            <div class="fallback-input-wrapper">
+              <input type="text" id="fallback-input" maxlength="1" autocomplete="off" class="mdc-text-field__input">
+              <div class="fallback-input-line"></div>
+            </div>
+            <button id="fallback-skip-btn" class="fallback-skip-btn">
+              Skip
+            </button>
+          </div>
+        </div>
       </div>
     </div>
     <div  id="progressbar"role="progressbar" class="mdc-linear-progress" aria-label="Example Progress Bar" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0">

--- a/src/index.scss
+++ b/src/index.scss
@@ -67,10 +67,123 @@ main,
   margin: 0
 }
 
+#target-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+}
+
 #target {
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+#fallback-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  pointer-events: none;
+}
+
+#fallback-prompt {
+  font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+  font-size: 1rem;
+  color: var(--mdc-theme-primary);
+  opacity: 0.7;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  z-index: 2;
+  pointer-events: auto;
+}
+
+.fallback-input-wrapper {
+  position: relative;
+  width: min(75vw, 75vh, 360px);
+  height: min(75vw, 75vh, 360px);
+  z-index: 2;
+  pointer-events: auto;
+  
+  #fallback-input {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: transparent;
+    text-align: center;
+    font-family: 'Noto Serif TC', 'Noto Serif SC', serif;
+    font-size: min(65vw, 65vh, 320px);
+    line-height: 1.2;
+    padding: 0;
+    margin: 0;
+    color: var(--mdc-theme-primary);
+    caret-color: var(--mdc-theme-secondary);
+    outline: none;
+    
+    &::placeholder {
+      color: var(--mdc-theme-surface);
+      opacity: 1;
+    }
+  }
+
+  .fallback-input-line {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: var(--mdc-theme-surface);
+    transition: background-color 0.3s ease, transform 0.3s ease;
+  }
+  
+  #fallback-input:focus ~ .fallback-input-line {
+    background-color: var(--mdc-theme-secondary);
+    transform: scaleX(1.1);
+  }
+
+  #fallback-input.success ~ .fallback-input-line {
+    background-color: #4caf50;
+    transform: scaleX(1.2);
+  }
+}
+
+.fallback-skip-btn {
+  margin-top: 2rem;
+  font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border-radius: 8px;
+  border: 1px solid var(--mdc-theme-surface);
+  color: var(--mdc-theme-primary);
+  background: transparent;
+  padding: 0.6rem 2rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  z-index: 2;
+  pointer-events: auto;
+  
+  &:hover {
+    background-color: var(--mdc-theme-surface);
+    border-color: var(--mdc-theme-secondary);
+    color: var(--mdc-theme-primary);
+  }
+  
+  &:active {
+    transform: scale(0.95);
+  }
 }
 
 #definitions {
@@ -1087,10 +1200,14 @@ main,
     flex: 1 1 auto;
   }
 
-  #target {
+  #target-wrapper {
     height: min(100vw, 100vh);
     width: min(100vw, 100vh);
     margin-top: auto;
+  }
+  #target {
+    width: 100%;
+    height: 100%;
   }
 
   #learned-stats-page {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,12 +47,16 @@ class App {
   type: 't'|'s';
   buffer_size: number;
   totalMistakes: number;
+  currentCharacter: string | null;
+  fallbackChar: string | null;
 
   constructor(db: IDBPDatabase<DB>) {
     this.enable_outline = false;
     const target = document.getElementById('target')!;
     const size = Math.min(target.clientWidth, target.clientHeight);
     this.db = db;
+    this.currentCharacter = null;
+    this.fallbackChar = null;
     this.charDataLoader = (char, onLoad, onError) => {
       const p0 = performance.now()
       if (this.db.version > 0) {
@@ -94,20 +98,48 @@ class App {
       renderer: 'svg',
       onLoadCharDataError: (error) => {
         console.warn(error);
-        if (typeof this.writer._options.onComplete === 'function') {
-          this.writer._options.onComplete({
-            character: this.writer._char!,
-            totalMistakes: 0
-          });
-        } else {
-          setTimeout(() => {
-            this.update_writer().catch(console.error);
-          }, 0);
-        }
+        const char = this.currentCharacter || this.writer._char || '一';
+        this.showFallbackInput(char);
       }
     });
     this.defaultCharDataLoader = this.writer._options.charDataLoader!;
     this.writer._options.charDataLoader = this.charDataLoader;
+
+    const fallbackInput = document.getElementById('fallback-input') as HTMLInputElement;
+    if (fallbackInput) {
+      const handleFallbackSubmit = () => {
+        const val = fallbackInput.value.trim();
+        if (val && val === this.fallbackChar) {
+          fallbackInput.classList.add('success');
+          this.panel.phrase += this.fallbackChar;
+          setTimeout(() => {
+            fallbackInput.classList.remove('success');
+            fallbackInput.value = '';
+            this.hideFallbackInput();
+            this.update_writer().catch(console.error);
+          }, 500);
+        }
+      };
+
+      fallbackInput.addEventListener('input', handleFallbackSubmit);
+      fallbackInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          handleFallbackSubmit();
+        }
+      });
+    }
+
+    const skipBtn = document.getElementById('fallback-skip-btn');
+    if (skipBtn) {
+      skipBtn.addEventListener('click', () => {
+        if (this.fallbackChar) {
+          this.panel.phrase += this.fallbackChar;
+          this.hideFallbackInput();
+          this.update_writer().catch(console.error);
+        }
+      });
+    }
+
     window.addEventListener('resize', () => {
       this.resize();
     });
@@ -361,11 +393,26 @@ class App {
     document.documentElement.style.setProperty('--mdc-theme-background', colors.background);
     document.documentElement.style.setProperty('--mdc-theme-surface', colors.outline);
 
-    this.writer.updateColor('strokeColor', colors.stroke);
-    this.writer.updateColor('highlightColor', colors.highlight);
-    this.writer.updateColor('highlightCompleteColor', this.color);
-    this.writer.updateColor('outlineColor', colors.outline);
-    this.writer.updateColor('drawingColor', colors.primary);
+    if (this.writer && (this.writer as any)._character) {
+      try {
+        this.writer.updateColor('strokeColor', colors.stroke);
+        this.writer.updateColor('highlightColor', colors.highlight);
+        this.writer.updateColor('highlightCompleteColor', this.color);
+        this.writer.updateColor('outlineColor', colors.outline);
+        this.writer.updateColor('drawingColor', colors.primary);
+      } catch (error) {
+        console.warn('Skipping HanziWriter color updates until character data is loaded:', error);
+      }
+    } else if (this.writer) {
+      const opts = (this.writer as any)._options;
+      if (opts) {
+        opts.strokeColor = colors.stroke;
+        opts.highlightColor = colors.highlight;
+        opts.highlightCompleteColor = this.color;
+        opts.outlineColor = colors.outline;
+        opts.drawingColor = colors.primary;
+      }
+    }
   }
 
   async updateBuffer() {
@@ -472,7 +519,10 @@ class App {
         this.updateProgress();
       }
       try {
-        this.writer.setCharacter(this.char_queue.pop()!);
+        const char = this.char_queue.pop()!;
+        this.currentCharacter = char;
+        this.hideFallbackInput();
+        this.writer.setCharacter(char);
         if (this.entry?.correct && this.entry?.correct > 0) {
           this.writer.hideOutline();
         } else {
@@ -484,6 +534,39 @@ class App {
       }
     }
     this.writer.quiz();
+  }
+
+  showFallbackInput(char: string) {
+    const container = document.getElementById('fallback-container')!;
+    const input = document.getElementById('fallback-input')! as HTMLInputElement;
+
+    const svg = document.querySelector('#target svg') as HTMLElement;
+    if (svg) {
+      svg.style.display = 'none';
+    }
+
+    input.value = '';
+    input.placeholder = char;
+    container.style.display = 'flex';
+    this.fallbackChar = char;
+
+    setTimeout(() => {
+      input.focus();
+    }, 50);
+  }
+
+  hideFallbackInput() {
+    const container = document.getElementById('fallback-container')!;
+    const input = document.getElementById('fallback-input')! as HTMLInputElement;
+
+    container.style.display = 'none';
+    input.value = '';
+    this.fallbackChar = null;
+
+    const svg = document.querySelector('#target svg') as HTMLElement;
+    if (svg) {
+      svg.style.display = '';
+    }
   }
 
   resize() {
@@ -503,6 +586,7 @@ async function main() {
 
   const db = (await Database.build()).db!;
   const app = new App(db);
+  (window as any).app = app;
   await app.load();
   initializeProbabilityCheckboxes();
   app.render();


### PR DESCRIPTION
Implement fallback text input overlay when Hanzi Writer fails to load character data (such as '説' or '咊'). This allows users to type or use their device's native handwriting keyboard to complete characters. Also adds a Skip button for rare characters that cannot be typed.