### PR TITLE
fix: consolidate Character/Simplified search filters into single Chinese scope

### DIFF
--- a/src/stats.html
+++ b/src/stats.html
@@ -80,11 +80,7 @@
             </button>
             <button type="button" class="mdc-chip stats-chip stats-scope-chip" data-scope="character" aria-pressed="false">
               <span class="mdc-chip__ripple"></span>
-              <span class="mdc-chip__text">Character</span>
-            </button>
-            <button type="button" class="mdc-chip stats-chip stats-scope-chip" data-scope="simplified" aria-pressed="false">
-              <span class="mdc-chip__ripple"></span>
-              <span class="mdc-chip__text">Simplified</span>
+              <span class="mdc-chip__text">Chinese</span>
             </button>
             <button type="button" class="mdc-chip stats-chip stats-scope-chip" data-scope="pinyin" aria-pressed="false">
               <span class="mdc-chip__ripple"></span>

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -26,7 +26,7 @@ type SearchScope = 'all' | 'character' | 'simplified' | 'pinyin' | 'jyutping' | 
 
 const SEARCH_PLACEHOLDERS: Record<SearchScope, string> = {
   all: 'characters, pinyin, jyutping, definitions, HSK',
-  character: 'Chinese characters',
+  character: 'Chinese characters (traditional & simplified)',
   simplified: 'simplified characters',
   pinyin: 'pinyin (bai, laoshi, xiangjiao)',
   jyutping: 'jyutping (maa5, gong2)',
@@ -65,9 +65,9 @@ const SCOPE_PREFIXES: Record<string, SearchScope> = {
   char: 'character',
   character: 'character',
   c: 'character',
-  simp: 'simplified',
-  simplified: 'simplified',
-  s: 'simplified',
+  simp: 'character',
+  simplified: 'character',
+  s: 'character',
   p: 'pinyin',
   py: 'pinyin',
   pinyin: 'pinyin',
@@ -1265,7 +1265,7 @@ async function main() {
   const scopeHint: Record<SearchScope, string> = {
     all: 'all',
     character: 'character',
-    simplified: 'simplified',
+    simplified: 'character',
     pinyin: 'p:',
     jyutping: 'j:',
     definition: 'e:',
@@ -1273,8 +1273,8 @@ async function main() {
   };
   const scopeLabel: Record<SearchScope, string> = {
     all: 'all fields',
-    character: 'character',
-    simplified: 'simplified',
+    character: 'Chinese characters',
+    simplified: 'Chinese characters',
     pinyin: 'pinyin',
     jyutping: 'jyutping',
     definition: 'definitions',


### PR DESCRIPTION
## Summary

The **Search In** filter had separate "Character" and "Simplified" chips, but the `character` scope already searched **both** traditional (`normT`) and simplified (`normS`) Chinese characters — making the "Simplified" chip redundant and confusing.

## Changes

- **Remove** the "Simplified" chip button from the Search In filter bar
- **Rename** "Character" → "Chinese" to make it clear both scripts are searched
- **Update** the search input placeholder to say "Chinese characters (traditional & simplified)"
- **Update** scope label to "Chinese characters" in status messages and badges
- **Redirect** `simp:`, `simplified:`, `s:` typed prefix aliases to the `character` scope so existing typed queries continue to work

## Before / After

| Before | After |
|--------|-------|
| All · Character · Simplified · Pinyin · Jyutping · English · HSK | All · **Chinese** · Pinyin · Jyutping · English · HSK |

No logic changes — the search behavior for Chinese characters is identical; this is purely a UI/labeling fix.