### PR TITLE
fix: fix service worker registration path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -772,7 +772,7 @@ async function main() {
   if (process.env.NODE_ENV === 'production') {
     if ('serviceWorker' in navigator) {
       try {
-        const registration = await navigator.serviceWorker.register('/sw.js')
+        const registration = await navigator.serviceWorker.register('./sw.js')
         console.log('Service worker registration succeeded:', registration);
       } catch (error) {
         console.log('Service worker registration failed:', error);


### PR DESCRIPTION
Changed the service worker registration path to be relative so it doesn't 404 when hosted on a subpath (e.g. GitHub Pages).