### PR TITLE
fix: skip waiting in service worker

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,8 +1,12 @@
 declare var self: ServiceWorkerGlobalScope;
 
+import { clientsClaim } from 'workbox-core';
 import { precacheAndRoute } from 'workbox-precaching';
 import {registerRoute} from 'workbox-routing';
 import {StaleWhileRevalidate} from 'workbox-strategies';
+
+(self as any).skipWaiting();
+clientsClaim();
 
 precacheAndRoute(self.__WB_MANIFEST)
 


### PR DESCRIPTION
Forces the service worker to skip waiting and claim clients so mobile devices receive updates immediately instead of getting stuck serving stale cache.