### PR TITLE
fix: auto-reload page when new service worker takes over

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -774,6 +774,18 @@ async function main() {
       try {
         const registration = await navigator.serviceWorker.register('./sw.js')
         console.log('Service worker registration succeeded:', registration);
+        
+        // Force the browser to check for service worker updates
+        registration.update();
+
+        // Automatically reload the page when a new service worker takes control
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (!refreshing) {
+            refreshing = true;
+            window.location.reload();
+          }
+        });
       } catch (error) {
         console.log('Service worker registration failed:', error);
       }


### PR DESCRIPTION
Added a `controllerchange` event listener in `main.ts` to automatically reload the app when the new service worker activates. This pairs with the previous skip waiting fix to ensure mobile apps immediately refresh to show the new cached application code instead of requiring a manual browser reload.