### PR TITLE
fix: resolve infinite reload loop caused by service worker

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -774,9 +774,6 @@ async function main() {
       try {
         const registration = await navigator.serviceWorker.register('./sw.js')
         console.log('Service worker registration succeeded:', registration);
-        
-        // Force the browser to check for service worker updates
-        registration.update();
 
         // Automatically reload the page when a new service worker takes control
         let refreshing = false;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -19,6 +19,6 @@ registerRoute(
 );
 
 registerRoute(
-  ({url}) => !url.pathname.endsWith('.json'),
+  ({url}) => !url.pathname.endsWith('.json') && !url.pathname.endsWith('sw.js'),
   new StaleWhileRevalidate()
 );


### PR DESCRIPTION
Removed aggressive `registration.update()` and excluded `sw.js` from `StaleWhileRevalidate` to prevent the service worker from caching itself and triggering continuous `controllerchange` events.