### PR TITLE
feat: implement config and enhanced queue sync

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -84,6 +84,7 @@ export default class Database {
       promises.push(tx.store.add([0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125], 'probabilities'));
       promises.push(tx.store.add(100, 'buffer_size'));
       promises.push(tx.store.add('traditional', 'type'));
+      promises.push(tx.store.add(Date.now(), 'updatedAt'));
       promises.push(tx.done);
       await Promise.all(promises);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {MDCCheckbox} from '@material/checkbox';
 import { MDCTextField } from '@material/textfield';
 import Panel from './panel';
 import { signInWithGoogle, signOut, onAuthChanged, getCurrentUser } from './firebase';
-import { SyncEngine, SyncStatus } from './sync';
+import { SyncEngine, SyncStatus, UserConfig } from './sync';
 
 const linearProgress = new MDCLinearProgress(document.querySelector('.mdc-linear-progress')!);
 const probabilityFields = ['dictionary', 'hsk-1', 'hsk-2', 'hsk-3', 'hsk-4', 'hsk-5', 'hsk-6', 'hsk-7', 'learned'] as const;
@@ -190,8 +190,6 @@ class App {
     const volumeFactor = Math.min(1, stats.successes / 5);
     stats.strength = accuracy * volumeFactor;
     entry.stats = stats;
-    // Queue for cloud sync
-    this.syncEngine.queueUpload(entry);
   }
 
   updateEntry() {
@@ -248,12 +246,15 @@ class App {
           }
           this.partitions[8].push(this.entry);
           promises.push(tx.store.put(this.partitions[8], 'learned'));
+          this.syncEngine.queueUpload(this.entry, 'learned');
         } else if (this.entry.correct >= 1) {
           const index = 0;
           this.partitions[9].splice(index, 0, this.entry);
+          this.syncEngine.queueUpload(this.entry, 'buffer');
         } else {
           const index = Math.floor(this.partitions[9].length * 0.8);
           this.partitions[9].splice(index, 0, this.entry);
+          this.syncEngine.queueUpload(this.entry, 'buffer');
         }
         promises.push(tx.store.put(this.partitions[9], 'buffer'));
         promises.push(tx.done);
@@ -263,6 +264,7 @@ class App {
         const index = Math.floor(this.partitions[9].length * 0.8);
         this.partitions[9].splice(index, 0, this.entry);
         await this.db.put('partitions', this.partitions[9], 'buffer');
+        this.syncEngine.queueUpload(this.entry, 'buffer');
       }
     }
 
@@ -612,6 +614,7 @@ async function main() {
   const app = new App(db);
   (window as any).app = app;
   await app.load();
+  await app.syncEngine.syncConfig(db, {}); // Initial sync for config after loading local config
   initializeProbabilityCheckboxes();
   app.render();
 
@@ -640,6 +643,12 @@ async function main() {
   onAuthChanged(async (user) => {
     updateAuthUI(user);
     if (user) {
+      const configModifiedLocally = await app.syncEngine.syncConfig(db, {}); // Sync config first
+      if (configModifiedLocally) {
+        // If config was modified locally (i.e. cloud was newer), reload app config.
+        await app.load(); // Reload app to reflect new config
+        app.render(); // Re-render if necessary
+      }
       const modifiedKeys = await app.syncEngine.fullSync(app.partitions, (i) => app.getPartitionKey(i));
       if (modifiedKeys.size > 0) {
         const tx = db.transaction('partitions', 'readwrite');
@@ -714,23 +723,56 @@ async function main() {
     const hadType = app.type;
     const textfield_color = new MDCTextField(document.getElementById('color-textfield')!);
     const promises = [];
+    let configUpdatedLocally = false;
+    const now = Date.now();
+
+    const newConfigForSync: Partial<UserConfig> = { updatedAt: now };
+
     if (radio_t.checked) {
       if (app.type !== 't') {
         app.type = 't';
-        promises.push(tx.store.put('t', 'traditional'));
+        newConfigForSync.type = 'traditional';
+        promises.push(tx.store.put('traditional', 'type'));
+        configUpdatedLocally = true;
       }
     } else if (app.type !== 's') {
       app.type = 's';
-      promises.push(tx.store.put('t', 'simplified'));
+      newConfigForSync.type = 'simplified';
+      promises.push(tx.store.put('simplified', 'type'));
+      configUpdatedLocally = true;
     }
 
     if (textfield_color.value !== app.color) {
+      app.color = textfield_color.value;
+      newConfigForSync.color = textfield_color.value;
       promises.push(tx.store.put(textfield_color.value, 'color'));
+      configUpdatedLocally = true;
     }
 
     const hadProbabilityChange = probabilities.some((value, index) => value !== app.probabilities[index]);
-    app.probabilities = probabilities;
-    promises.push(tx.store.put(probabilities, 'probabilities'));
+    if (hadProbabilityChange) {
+      app.probabilities = probabilities;
+      newConfigForSync.probabilities = probabilities;
+      promises.push(tx.store.put(probabilities, 'probabilities'));
+      configUpdatedLocally = true;
+    }
+
+    if (configUpdatedLocally) {
+      promises.push(tx.store.put(now, 'updatedAt'));
+    }
+    
+    // Check buffer_size, which is not in the form but part of config.
+    // If it was modified (e.g. by another synced device), we need to reflect that.
+    // Here we assume app.buffer_size is already updated from local DB.
+    // When config is synced from cloud, app.buffer_size will be updated in app.load()
+    const currentBufferSizeInDb = await db.get('config', 'buffer_size');
+    if (currentBufferSizeInDb !== app.buffer_size) {
+      // This case handles external changes from cloud sync.
+      // If we manually change buffer_size in the future from UI, we need to add a UI element and form field.
+      // For now, assume it's set by app.load and potentially overwritten by cloud sync.
+    }
+
+
     if (promises.length > 0) {
       promises.push(tx.done);
       await Promise.all(promises);
@@ -744,6 +786,9 @@ async function main() {
         app.totalMistakes = 0;
         await app.updateBuffer();
         await app.update_writer();
+      }
+      if (configUpdatedLocally) {
+        await app.syncEngine.syncConfig(db, newConfigForSync);
       }
     }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -740,7 +740,9 @@ function createQueueStateBadge(state: QueueState, isLearned: boolean) {
 function createActionButton(
   entry: PartitionElement,
   state: QueueState,
-  onAdd: (entry: PartitionElement) => Promise<boolean>,
+  db: IDBPDatabase<DB>,
+  syncEngine: SyncEngine,
+  onAdd: (entry: PartitionElement, db: IDBPDatabase<DB>, syncEngine: SyncEngine) => Promise<boolean>,
   isLearned: boolean,
   onStateChange?: (nextState: QueueState) => void,
 ) {
@@ -790,7 +792,7 @@ function createActionButton(
     icon.textContent = 'hourglass_empty';
 
     try {
-      const added = await onAdd(entry);
+      const added = await onAdd(entry, db, syncEngine);
       if (added) {
         onStateChange?.('queued');
         button.disabled = true;
@@ -866,7 +868,9 @@ function createStrengthCell(value: number | undefined, label?: string, className
 function createStatRows(
   entry: PartitionElement,
   queueState: QueueState,
-  onAdd: (entry: PartitionElement) => Promise<boolean>,
+  db: IDBPDatabase<DB>,
+  syncEngine: SyncEngine,
+  onAdd: (entry: PartitionElement, db: IDBPDatabase<DB>, syncEngine: SyncEngine) => Promise<boolean>,
   isLearned: boolean,
   searchTerms: Array<string>,
 ) {
@@ -954,7 +958,7 @@ function createStatRows(
   const actionCell = document.createElement('div');
   actionCell.className = 'stats-card-field stats-action-cell';
   actionCell.dataset.label = 'Queue';
-  const actionButton = createActionButton(entry, queueState, onAdd, isLearned, updateQueueStateVisuals);
+  const actionButton = createActionButton(entry, queueState, db, syncEngine, onAdd, isLearned, updateQueueStateVisuals);
   actionButtonRef = actionButton;
   actionCell.appendChild(actionButton);
   card.appendChild(actionCell);
@@ -973,7 +977,7 @@ function clearChildren(node: HTMLElement) {
   }
 }
 
-async function addToLearningQueue(db: IDBPDatabase<DB>, entry: PartitionElement) {
+async function addToLearningQueue(db: IDBPDatabase<DB>, entry: PartitionElement, syncEngine: SyncEngine) {
   const tx = db.transaction(['partitions', 'partition-lengths'], 'readwrite');
   const partitionStore = tx.objectStore('partitions');
   const lengthStore = tx.objectStore('partition-lengths');
@@ -1005,6 +1009,8 @@ async function addToLearningQueue(db: IDBPDatabase<DB>, entry: PartitionElement)
   await partitionStore.put(next, 'buffer');
   await lengthStore.put(next.length, 'buffer');
   await tx.done;
+  
+  syncEngine.queueUpload(clone, 'buffer');
 
   return true;
 }
@@ -1573,8 +1579,8 @@ async function main() {
         addedThisRender += 1;
         const state = getQueueState(entry, queued.has(entry.t), isEntrySelected(entry));
         const isLearned = statusFor(entry, queued) === 'learned';
-        fragment.appendChild(createStatRows(entry, state, async () => {
-          const added = await addToLearningQueue(db, entry);
+        fragment.appendChild(createStatRows(entry, state, db, syncEngine, async (entry, db, syncEngine) => {
+          const added = await addToLearningQueue(db, entry, syncEngine);
           if (added) {
             queued.add(entry.t);
             const counts = computeCounts(filtered);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,13 +1,16 @@
+import { IDBPDatabase } from 'idb';
 import {
   collection,
   doc,
   getDocs,
   writeBatch,
+  getDoc,
+  setDoc,
   Firestore,
 } from 'firebase/firestore';
 import { User } from 'firebase/auth';
 import { firestore, getCurrentUser } from './firebase';
-import { PartitionElement } from './database';
+import { PartitionElement, DB } from './database';
 import { LearningStats } from './dict';
 
 export interface WordProgress {
@@ -15,6 +18,7 @@ export interface WordProgress {
   correct: number;
   stats: Required<LearningStats>;
   updatedAt: number;
+  state?: 'buffer' | 'learned';
 }
 
 /** Encode a word's traditional character as a safe Firestore document ID */
@@ -26,9 +30,9 @@ function decodeWordId(id: string): string {
   return decodeURIComponent(id);
 }
 
-function entryToWordProgress(entry: PartitionElement): WordProgress {
+function entryToWordProgress(entry: PartitionElement, state?: 'buffer' | 'learned'): WordProgress {
   const now = Date.now();
-  return {
+  const progress: WordProgress = {
     t: entry.t,
     correct: entry.correct ?? 0,
     stats: {
@@ -42,9 +46,14 @@ function entryToWordProgress(entry: PartitionElement): WordProgress {
     },
     updatedAt: entry.stats?.updatedAt ?? now,
   };
+  if (state) {
+    progress.state = state;
+  }
+  return progress;
 }
 
-function hasProgress(entry: PartitionElement): boolean {
+function hasProgress(entry: PartitionElement, state?: 'buffer' | 'learned'): boolean {
+  if (state === 'buffer' || state === 'learned') return true;
   if (entry.correct && entry.correct > 0) return true;
   if (!entry.stats) return false;
   return (entry.stats.attempts ?? 0) > 0
@@ -158,11 +167,11 @@ export class SyncEngine {
   /**
    * Queue a changed entry for upload. Will be flushed after the debounce interval.
    */
-  queueUpload(entry: PartitionElement): void {
+  queueUpload(entry: PartitionElement, state?: 'buffer' | 'learned'): void {
     const user = getCurrentUser();
     if (!user) return;
 
-    const progress = entryToWordProgress(entry);
+    const progress = entryToWordProgress(entry, state);
     this.uploadQueue.set(entry.t, progress);
 
     if (this.flushTimer) {
@@ -211,6 +220,7 @@ export class SyncEngine {
           correct: entry.correct,
           stats: entry.stats,
           updatedAt: entry.updatedAt,
+          ...(entry.state ? { state: entry.state } : {})
         });
       }
 
@@ -267,26 +277,48 @@ export class SyncEngine {
       for (const [t, cloudEntry] of cloudProgress) {
         const localRef = localIndex.get(t);
         if (localRef) {
+          const localState = localRef.pi === 8 ? 'learned' : localRef.pi === 9 ? 'buffer' : undefined;
           const localEntry = partitions[localRef.pi][localRef.ei];
           const wasModified = mergeCloudIntoLocal(localEntry, cloudEntry);
-          if (wasModified) {
-            modifiedPartitions.add(getPartitionKey(localRef.pi));
+          
+          let needsMove = false;
+          if (cloudEntry.updatedAt >= (localEntry.stats?.updatedAt ?? 0)) {
+            if (cloudEntry.state && cloudEntry.state !== localState) {
+              needsMove = true;
+            }
           }
+          
+          if (wasModified || needsMove) {
+            if (needsMove && cloudEntry.state) {
+              // Move the entry to the new partition structurally
+              partitions[localRef.pi].splice(localRef.ei, 1);
+              modifiedPartitions.add(getPartitionKey(localRef.pi));
+              
+              const targetPi = cloudEntry.state === 'learned' ? 8 : cloudEntry.state === 'buffer' ? 9 : -1;
+              if (targetPi !== -1 && targetPi < partitions.length) {
+                partitions[targetPi].push(localEntry);
+                modifiedPartitions.add(getPartitionKey(targetPi));
+              }
+            } else {
+              modifiedPartitions.add(getPartitionKey(localRef.pi));
+            }
+          }
+          
           // If local is newer, queue for upload
           const localUpdatedAt = localEntry.stats?.updatedAt ?? 0;
           if (localUpdatedAt > (cloudEntry.updatedAt ?? 0)) {
-            toUpload.push(entryToWordProgress(localEntry));
+            toUpload.push(entryToWordProgress(localEntry, localState));
           }
         }
         // Words in cloud but not in local partitions are ignored
-        // (they may be from a different version of partitions.json)
       }
 
       // 4. For each local entry with progress that's not in cloud, upload it
       for (let pi = 0; pi < partitions.length; pi++) {
+        const localState = pi === 8 ? 'learned' : pi === 9 ? 'buffer' : undefined;
         for (const entry of partitions[pi]) {
-          if (hasProgress(entry) && !cloudProgress.has(entry.t)) {
-            toUpload.push(entryToWordProgress(entry));
+          if (hasProgress(entry, localState) && !cloudProgress.has(entry.t)) {
+            toUpload.push(entryToWordProgress(entry, localState));
           }
         }
       }
@@ -311,4 +343,88 @@ export class SyncEngine {
       return new Set();
     }
   }
+
+  // --- Config Sync ---
+  async syncConfig(db: IDBPDatabase<DB>, newConfig?: Partial<UserConfig>): Promise<boolean> {
+    const user = getCurrentUser();
+    if (!user) return false;
+
+    this.setStatus('syncing');
+    try {
+      const configDocRef = doc(firestore, 'users', user.uid, 'config', 'settings');
+      const cloudSnapshot = await getDoc(configDocRef);
+      const cloudConfig = cloudSnapshot.exists() ? (cloudSnapshot.data() as UserConfig) : null;
+
+      const localConfigKeys = ['color', 'type', 'probabilities', 'buffer_size'];
+      const localConfig: Partial<UserConfig> = {};
+      let localUpdatedAt = 0;
+
+      const tx = db.transaction('config', 'readwrite');
+      for (const key of localConfigKeys) {
+        const value = await tx.store.get(key);
+        if (value !== undefined) {
+          (localConfig as any)[key] = value;
+        }
+      }
+      localUpdatedAt = await tx.store.get('updatedAt') || 0;
+      await tx.done;
+
+      let mergedConfig: Partial<UserConfig> = {};
+      let changedLocally = false;
+      let changedRemotely = false;
+
+      if (cloudConfig && cloudConfig.updatedAt > localUpdatedAt) {
+        // Cloud is newer, take cloud config
+        mergedConfig = { ...cloudConfig };
+        changedLocally = true; // Will write cloud to local
+      } else if (localUpdatedAt > (cloudConfig?.updatedAt ?? 0)) {
+        // Local is newer, take local config and upload
+        mergedConfig = { ...localConfig, updatedAt: localUpdatedAt };
+        changedRemotely = true; // Will upload local to cloud
+      } else {
+        // Either both are same age, or one/both don't exist, or local has no progress
+        // Default to local if exists, otherwise cloud, otherwise default values
+        mergedConfig = { ...(cloudConfig || localConfig) };
+        if (!mergedConfig.updatedAt) {
+          mergedConfig.updatedAt = Date.now();
+          if (localConfigKeys.some(key => (localConfig as any)[key] !== undefined)) {
+            changedRemotely = true; // Upload if local existed but no updatedAt
+          }
+        }
+      }
+
+      // Write merged config to local IndexedDB if changed
+      if (changedLocally || changedRemotely || (cloudConfig && !localUpdatedAt)) { // Also write if cloud existed but local didn't have updatedAt
+        const newLocalTx = db.transaction('config', 'readwrite');
+        for (const key of localConfigKeys) {
+          if ((mergedConfig as any)[key] !== undefined) {
+            await newLocalTx.store.put((mergedConfig as any)[key], key);
+          }
+        }
+        await newLocalTx.store.put(mergedConfig.updatedAt!, 'updatedAt');
+        await newLocalTx.done;
+      }
+
+      // Upload merged config to Firestore if changed
+      if (changedRemotely || (changedLocally && !localUpdatedAt)) { // If cloud was newer, and local had no updatedAt, still upload.
+        await setDoc(configDocRef, mergedConfig);
+      }
+      
+      this.setStatus('synced');
+      return changedLocally; // Return true if local IndexedDB was updated
+    } catch (error) {
+      console.error('Config sync failed:', error);
+      this.setStatus('error');
+      return false;
+    }
+  }
+}
+
+// Define UserConfig interface
+export interface UserConfig {
+  color?: string;
+  type?: 'traditional' | 'simplified';
+  probabilities?: number[];
+  buffer_size?: number;
+  updatedAt: number;
 }


### PR DESCRIPTION
This commit resolves issues with both queue item and user settings synchronization.

Key changes include:
- **Config Sync:** Implemented `syncConfig` method in `SyncEngine` to perform bidirectional syncing of user configuration (color, type, probabilities, buffer_size) with Firestore. This ensures settings persist across devices using an `updatedAt` timestamp for conflict resolution.
- **Enhanced `fullSync`:** Modified `fullSync` to use a new `state` field in `WordProgress` to correctly manage structural moves of words between 'buffer' and 'learned' partitions during synchronization.
- **Improved `queueUpload` Calls:** Updated `main.ts` and `stats.ts` to call `syncEngine.queueUpload` with the appropriate `state` ('buffer' or 'learned') whenever an entry's partition changes, ensuring queue status is accurately reflected in the cloud.
- **Config Auto-Sync:** Integrated `syncConfig` to run upon app load, user login, and each time settings are saved, as well as upon user login to ensure a consistent experience across devices.
- **Type Safety & Scope Fixes:** Addressed all TypeScript compilation errors related to `UserConfig` imports, `IDBPDatabase<DB>` scope, and function parameter passing.