### PR TITLE
Fix reload loop on stats page during sync

### DIFF
--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1128,8 +1128,13 @@ async function main() {
         }
       }
       await tx.done;
-      // Reload the page to reflect synced changes in the stats view
-      location.reload();
+      
+      // Prevent reload loop by checking if we already reloaded due to sync in this page load session
+      const syncReloadKey = 'stats_sync_reloaded';
+      if (!sessionStorage.getItem(syncReloadKey)) {
+        sessionStorage.setItem(syncReloadKey, 'true');
+        location.reload();
+      }
     }
   };
 


### PR DESCRIPTION
This PR fixes a reload loop on the stats page. When Firestore sync completes, location.reload() is triggered to display the new counts and progress data in the stats UI. However, after reloading, the auth listener fires again, triggering a new sync request which returns modifications and triggers another reload. This fix uses sessionStorage to track whether we have already reloaded due to a sync during the current browsing session to break the loop.