### PR TITLE
Fix infinite reload loop on stats page during sync

### DIFF
--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1129,10 +1129,11 @@ async function main() {
       }
       await tx.done;
       
-      // Prevent reload loop by checking if we already reloaded due to sync in this page load session
-      const syncReloadKey = 'stats_sync_reloaded';
-      if (!sessionStorage.getItem(syncReloadKey)) {
-        sessionStorage.setItem(syncReloadKey, 'true');
+      // Prevent reload loop by checking if we already reloaded due to sync recently
+      const lastReloadTime = sessionStorage.getItem('stats_last_sync_reload_time');
+      const now = Date.now();
+      if (!lastReloadTime || now - parseInt(lastReloadTime, 10) > 10000) {
+        sessionStorage.setItem('stats_last_sync_reload_time', String(now));
         location.reload();
       }
     }


### PR DESCRIPTION
This PR fixes the stats page infinite reload loop. When progress data is synced from the cloud on page load, location.reload is triggered. This caused auth state to resolve again, firing a new fullSync which returned modifications and looped infinitely. This fix introduces a 10-second debounce check using sessionStorage timestamps to prevent the sync-induced reload loop.